### PR TITLE
Use local SQLite fallback instead of mandatory DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@ One-file NFL Telegram Bot (2025-only, legal sources, no fake data).
 ```
 pip install -r requirements.txt
 export TELEGRAM_BOT_TOKEN=...
-export DATABASE_URL=postgresql+psycopg://user:pass@host:5432/dbname
+# Optional: override default SQLite DB with PostgreSQL
+# export DATABASE_URL=postgresql+psycopg://user:pass@host:5432/dbname
 python app.py migrate        # apply SQL migrations
 python app.py bot            # run Telegram bot
 python app.py refresh        # run collectors → features → model → picks once
 ```
+
+By default the application stores data in a local SQLite file named
+`proballers.db`.  Setting `DATABASE_URL` allows pointing at a PostgreSQL
+database instead.
+
+The collectors use [cloudscraper](https://pypi.org/project/cloudscraper/)
+so scraping protected sites continues to work without manual cookies.
 
 ### Commands
 - `/player First Last` – show recent projections

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ statsmodels
 scikit-learn
 feedparser
 beautifulsoup4
-httpx
+cloudscraper
 tenacity
 python-dateutil
 robotexclusionrulesparser


### PR DESCRIPTION
## Summary
- Default to a local SQLite database when `DATABASE_URL` is not set
- Remove mandatory `DATABASE_URL` checks so bot and refresh can run without Postgres
- Fetch NFL injuries and news through a shared `cloudscraper` session to better handle protected sites
- Document `cloudscraper` usage and add it to requirements

## Testing
- `python -m py_compile app.py`
- `python app.py migrate` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic sqlalchemy numpy python-telegram-bot feedparser beautifulsoup4 python-dateutil cloudscraper` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_6897cbf14f188327b790c87e036f9838