### PR TITLE
Add CLI defaults and Telegram player stats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tenacity
 python-dateutil
 robotexclusionrulesparser
 uvloop; platform_system != 'Windows'
+pydantic


### PR DESCRIPTION
## Summary
- switch settings to Pydantic model with SQLite fallback and create engine from resolved DB URL
- allow Telegram users to send plain player names and receive latest stats
- refine CLI entry so migrations run automatically and bot is default command

## Testing
- `python -m py_compile app.py`
- `pip install pydantic python-telegram-bot SQLAlchemy feedparser cloudscraper beautifulsoup4 python-dateutil robotexclusionrulesparser tenacity numpy` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_6898d98123948327a61d63702c7f5a11